### PR TITLE
fix: 인증 미들웨어 토큰 파싱 표준화 (#43)

### DIFF
--- a/src/middlewares/userAuthorization.js
+++ b/src/middlewares/userAuthorization.js
@@ -1,40 +1,41 @@
 import jwt from '../utils/jwt.js';
 import { buildResponse } from '../misc/utils.js';
 
-const userAuthorization = async (req, res, next) => {
-  // const auth = req.headers.authorization;
-  // const Token = req.cookies.token;
-  const serverToken = req.headers.token;
-  const clientToken = req.cookies.token;
-  // const userToken = auth?.split(' ')[1];
+const UNAUTHORIZED_ERROR = {
+  statusCode: 401,
+  result: 'Unauthorized',
+  reason: '로그인한 유저만 사용할 수 있는 서비스입니다.'
+};
 
-  if (
-    (!serverToken || serverToken === 'null') &&
-    (!clientToken || clientToken === 'null')
-  ) {
-    return res.json(
-      buildResponse({
-        status: 401,
-        result: 'Unauthorized',
-        reason: '로그인한 유저만 사용할 수 있는 서비스입니다.'
-      })
-    );
+const extractBearerToken = (authorizationHeader) => {
+  if (!authorizationHeader || typeof authorizationHeader !== 'string') {
+    return null;
+  }
+
+  const [scheme, token] = authorizationHeader.split(' ');
+  if (scheme !== 'Bearer' || !token) {
+    return null;
+  }
+
+  return token;
+};
+
+const userAuthorization = async (req, res, next) => {
+  const headerToken = extractBearerToken(req.headers.authorization);
+  const clientToken = req.cookies.token;
+
+  if ((!headerToken || headerToken === 'null') && (!clientToken || clientToken === 'null')) {
+    return res.status(401).json(buildResponse(null, UNAUTHORIZED_ERROR));
   }
 
   try {
-    const { userId } = jwt.verify(serverToken ?? clientToken);
+    const { userId } = jwt.verify(headerToken ?? clientToken);
 
     req.currentUserId = userId;
 
-    next();
+    return next();
   } catch (err) {
-    return res.json(
-      buildResponse({
-        status: 401,
-        result: 'Unauthorized',
-        reason: '로그인한 유저만 사용할 수 있는 서비스입니다.'
-      })
-    );
+    return res.status(401).json(buildResponse(null, UNAUTHORIZED_ERROR));
   }
 };
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  namespace Express {
+    interface Request {
+      currentUserId?: string;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
### 📝 작업 개요

- 인증 미들웨어의 토큰 파싱 규칙을 표준화하고, 실패 응답을 401 상태코드로 고정했습니다.

### 🔧 주요 변경 사항

- `src/middlewares/userAuthorization.js`
- `Authorization: Bearer <token>` 우선 파싱
- 쿠키 `token`을 보조 수단으로 사용
- 인증 실패 시 `res.status(401)`로 응답
- 에러 응답을 `buildResponse(null, UNAUTHORIZED_ERROR)`로 통일
- `src/types/express.d.ts` 추가
- `req.currentUserId` 타입 확장 선언 추가

### 🎯 변경 목적

- 표준 인증 헤더 흐름과 호환성을 확보하기 위함입니다.
- 클라이언트가 인증 실패를 정상 응답으로 오인하지 않도록 하기 위함입니다.
- TypeScript 마이그레이션 시 요청 타입 확장의 기반을 마련하기 위함입니다.

### 🧪 검증 방법

- `node --check src/middlewares/userAuthorization.js`
- `rg -n "headers\\.token|extractBearerToken|currentUserId" src/middlewares/userAuthorization.js src/types/express.d.ts`

### 📌 참고 사항

- `npm run lint`, `npm run build` 스크립트가 현재 프로젝트에 없습니다.
- `npm run test`는 기본 placeholder 스크립트(`exit 1`)라 유의미한 자동 검증으로 사용하지 않았습니다.

---

Closes #43
