### PR TITLE
fix: MongoDB 연결 실패/중단 대응 구현 (#42)

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,14 +16,22 @@ const config = {
   DB_URL: process.env.DB_URL
 };
 
-// -------------------- MongoDB 연결 --------------------
-mongoose.connect(config.DB_URL, {
-  dbName: 'Todo-Tamers'
+let isShuttingDown = false;
+
+mongoose.connection.on('connected', () => {
+  console.log('정상적으로 MongoDB 서버에 연결되었습니다.');
 });
 
-mongoose.connection.on('connected', () =>
-  console.log('정상적으로 MongoDB 서버에 연결되었습니다.')
-);
+mongoose.connection.on('error', (err) => {
+  console.error('[MongoDB] connection error:', err);
+});
+
+mongoose.connection.on('disconnected', () => {
+  console.error('[MongoDB] disconnected.');
+  if (!isShuttingDown) {
+    process.exit(1);
+  }
+});
 
 // -------------------- CORS 설정 --------------------
 const allowedOrigins = [
@@ -65,9 +73,44 @@ app.use(cookieParser());
 app.use('/api/v1', authRouter);
 app.use('/api/v1', userAuthorization, v1);
 
-// -------------------- 서버 시작 --------------------
-app.listen(config.PORT, function () {
-  console.log(`서버가 ${config.PORT}에서 실행 중....`);
-});
+const connectDatabase = async () => {
+  try {
+    await mongoose.connect(config.DB_URL, {
+      dbName: 'Todo-Tamers'
+    });
+  } catch (err) {
+    console.error('[MongoDB] initial connect failed:', err);
+    process.exit(1);
+  }
+};
+
+const startServer = async () => {
+  await connectDatabase();
+
+  const server = app.listen(config.PORT, () => {
+    console.log(`서버가 ${config.PORT}에서 실행 중....`);
+  });
+
+  const gracefulShutdown = async (signal) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+    console.log(`[Server] ${signal} received. shutting down...`);
+
+    server.close(async () => {
+      try {
+        await mongoose.connection.close(false);
+        process.exit(0);
+      } catch (err) {
+        console.error('[MongoDB] close failed:', err);
+        process.exit(1);
+      }
+    });
+  };
+
+  process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+  process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+};
+
+startServer();
 
 export default app;


### PR DESCRIPTION
### 📝 작업 개요

- MongoDB 연결 실패/중단 시나리오 대응을 추가하고, DB 준비 후 서버가 기동되도록 부팅 순서를 분리했습니다.

### 🔧 주요 변경 사항

- `app.js`에 DB 연결 수명주기 이벤트 핸들러 추가
- `connected`, `error`, `disconnected` 처리
- 초기 연결 실패 시 fail-fast (`process.exit(1)`) 적용
- `connectDatabase()`/`startServer()`로 listen 시점 분리
- `SIGINT`, `SIGTERM` graceful shutdown 처리 추가

### 🎯 변경 목적

- DB 미연결 상태에서 API가 요청을 받는 상황을 방지하기 위함입니다.
- 런타임 장애 시 서비스 상태를 더 명확하게 드러내기 위함입니다.

### 🧪 검증 방법

- `node --check app.js`
- `rg -n "connectDatabase|startServer|SIGINT|disconnected|initial connect failed" app.js`

### 📌 참고 사항

- `npm run lint`, `npm run build` 스크립트가 현재 프로젝트에 없습니다.
- `npm run test`는 기본 placeholder 스크립트(`exit 1`)라 유의미한 자동 검증으로 사용하지 않았습니다.

---

Closes #42
