### PR TITLE
fix: todo categoryId ObjectId 정규화 적용 (#50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node ./app.js",
     "dev": "nodemon",
-    "build": "tsc"
+    "build": "tsc",
+    "migrate:todo-category-id": "node ./scripts/migrateTodoCategoryIdToObjectId.js"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",

--- a/scripts/migrateTodoCategoryIdToObjectId.js
+++ b/scripts/migrateTodoCategoryIdToObjectId.js
@@ -1,0 +1,82 @@
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+
+dotenv.config();
+
+const config = {
+  DB_URL: process.env.DB_URL,
+  DB_NAME: 'Todo-Tamers'
+};
+
+if (!config.DB_URL) {
+  console.error('[Migration] DB_URL is required.');
+  process.exit(1);
+}
+
+const todoContentSchema = new mongoose.Schema(
+  {
+    categoryId: { type: mongoose.Schema.Types.Mixed }
+  },
+  {
+    strict: false,
+    collection: 'todoContents'
+  }
+);
+
+const TodoContent = mongoose.model(
+  'TodoContentCategoryIdMigration',
+  todoContentSchema
+);
+
+const migrate = async () => {
+  await mongoose.connect(config.DB_URL, { dbName: config.DB_NAME });
+
+  const docs = await TodoContent.find({ categoryId: { $type: 'string' } })
+    .select({ _id: 1, categoryId: 1 })
+    .lean();
+
+  if (!docs.length) {
+    console.log('[Migration] No string categoryId found.');
+    await mongoose.connection.close();
+    return;
+  }
+
+  const bulkOps = [];
+  let skipped = 0;
+
+  for (const doc of docs) {
+    if (!mongoose.Types.ObjectId.isValid(doc.categoryId)) {
+      skipped += 1;
+      continue;
+    }
+
+    bulkOps.push({
+      updateOne: {
+        filter: { _id: doc._id },
+        update: { $set: { categoryId: new mongoose.Types.ObjectId(doc.categoryId) } }
+      }
+    });
+  }
+
+  if (bulkOps.length > 0) {
+    const result = await TodoContent.bulkWrite(bulkOps, { ordered: false });
+    console.log('[Migration] converted:', result.modifiedCount);
+  } else {
+    console.log('[Migration] no valid string categoryId to convert.');
+  }
+
+  await TodoContent.collection.createIndex({ categoryId: 1, createdAt: 1 });
+  console.log('[Migration] index ensured: { categoryId: 1, createdAt: 1 }');
+
+  if (skipped > 0) {
+    console.warn('[Migration] skipped invalid categoryId:', skipped);
+  }
+
+  await mongoose.connection.close();
+};
+
+migrate().catch(async (err) => {
+  console.error('[Migration] failed:', err);
+  await mongoose.connection.close();
+  process.exit(1);
+});

--- a/src/db/schemas/todoContentSchema.js
+++ b/src/db/schemas/todoContentSchema.js
@@ -3,7 +3,8 @@ import { Schema } from 'mongoose';
 const todoContentSchema = new Schema(
     {
         categoryId: {
-            type: String,
+            type: Schema.Types.ObjectId,
+            ref: 'todoCategories',
             required: true
         },
         todo: {
@@ -21,5 +22,7 @@ const todoContentSchema = new Schema(
         versionKey: false
     }
 );
+
+todoContentSchema.index({ categoryId: 1, createdAt: 1 });
 
 export default todoContentSchema;

--- a/src/services/todoContentService.js
+++ b/src/services/todoContentService.js
@@ -25,7 +25,7 @@ class TodoContentService {
     // 사용자의 각 카테고리에 대해 비동기 작업을 병렬로 시작
     const promises = categories.map(async (category) => {
       const todos = await todoContentModel.findByCategoryId(
-        category._id.toString(),
+        category._id,
         startDate,
         endDate
       );
@@ -113,7 +113,7 @@ class TodoContentService {
     if (categoryId) {
       for (let i = 0; i < categoryId.length; i++) {
         await todoContentModel.deleteTodoContentByCategoryId(
-          categoryId[i]._id.toString()
+          categoryId[i]._id
         );
       }
     }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -47,14 +47,14 @@ class UserService {
       category: '목표1'
     });
     await this.todoContentService.addContent({
-      categoryId: category1._id.toString(),
+      categoryId: category1._id,
       todo: '할일1',
       date: formatDateToString(
         new Date(new Date().getTime() + 9 * 60 * 60 * 1000)
       )
     });
     await this.todoContentService.addContent({
-      categoryId: category1._id.toString(),
+      categoryId: category1._id,
       todo: '할일2',
       date: formatDateToString(
         new Date(new Date().getTime() + 9 * 60 * 60 * 1000)
@@ -65,14 +65,14 @@ class UserService {
       category: '목표2'
     });
     await this.todoContentService.addContent({
-      categoryId: category2._id.toString(),
+      categoryId: category2._id,
       todo: '할일3',
       date: formatDateToString(
         new Date(new Date().getTime() + 9 * 60 * 60 * 1000)
       )
     });
     await this.todoContentService.addContent({
-      categoryId: category2._id.toString(),
+      categoryId: category2._id,
       todo: '할일4',
       date: formatDateToString(
         new Date(new Date().getTime() + 9 * 60 * 60 * 1000)


### PR DESCRIPTION
### 📝 작업 개요

- `todoContent.categoryId`를 문자열에서 `ObjectId` 참조로 정규화하고, 기존 데이터 변환용 마이그레이션 스크립트를 추가했습니다.

### 🔧 주요 변경 사항

- 스키마 변경
- `src/db/schemas/todoContentSchema.js`
- `categoryId`를 `Schema.Types.ObjectId` + `ref: 'todoCategories'`로 변경
- 복합 인덱스 추가: `{ categoryId: 1, createdAt: 1 }`
- 서비스/쿼리 타입 정합성 개선
- `src/services/todoContentService.js`: 카테고리 `_id.toString()` 사용 제거
- `src/services/userService.js`: 초기 todo 생성 시 `categoryId`에 ObjectId 직접 전달
- 마이그레이션 스크립트 추가
- `scripts/migrateTodoCategoryIdToObjectId.js`
- 기존 string `categoryId`를 ObjectId로 변환
- 유효하지 않은 값은 스킵 후 로그 출력
- 인덱스 생성 보장
- 실행 스크립트 추가
- `package.json`: `migrate:todo-category-id`

### 🎯 변경 목적

- 참조 무결성과 타입 일관성을 확보하고, 카테고리 기반 조회 성능(인덱스 활용)을 개선하기 위함입니다.

### 🧪 검증 방법

- `npm run build` 실행 성공
- `node --check scripts/migrateTodoCategoryIdToObjectId.js` 실행 성공
- `rg -n "categoryId|toString\\(" ...`로 `categoryId` 경로 점검

### 📌 참고 사항

- 데이터 변환은 배포 환경에서 `npm run migrate:todo-category-id`로 1회 수행이 필요합니다.

---

Closes #50
