### PR TITLE
fix: 인벤토리 수량 갱신 원자화 적용 (#48)

### DIFF
--- a/src/db/models/inventoryModel.js
+++ b/src/db/models/inventoryModel.js
@@ -29,6 +29,121 @@ class InventoryModel {
             _id: inventoryId
         }).lean();
     }
+
+    async adjustItemQuantityByInventoryItemId(
+        inventoryId,
+        inventoryItemId,
+        quantityDelta,
+        requireAvailable = false
+    ) {
+        const filter = requireAvailable && quantityDelta < 0
+            ? {
+                  _id: inventoryId,
+                  items: {
+                      $elemMatch: {
+                          _id: inventoryItemId,
+                          quantity: { $gte: Math.abs(quantityDelta) }
+                      }
+                  }
+              }
+            : {
+                  _id: inventoryId,
+                  'items._id': inventoryItemId
+              };
+
+        return await InventoryCategory.findOneAndUpdate(
+            filter,
+            { $inc: { 'items.$.quantity': quantityDelta } },
+            { new: true }
+        ).lean();
+    }
+
+    async adjustItemQuantityByItemId(inventoryId, itemId, quantityDelta) {
+        return await InventoryCategory.findOneAndUpdate(
+            {
+                _id: inventoryId,
+                'items.item': itemId
+            },
+            {
+                $inc: {
+                    'items.$.quantity': quantityDelta
+                }
+            },
+            { new: true }
+        ).lean();
+    }
+
+    async addItemIfNotExists(inventoryId, itemId, quantity) {
+        return await InventoryCategory.findOneAndUpdate(
+            {
+                _id: inventoryId,
+                'items.item': { $ne: itemId }
+            },
+            {
+                $push: {
+                    items: { item: itemId, quantity }
+                }
+            },
+            { new: true }
+        ).lean();
+    }
+
+    async removeInventoryItem(inventoryId, inventoryItemId) {
+        return await InventoryCategory.findOneAndUpdate(
+            { _id: inventoryId },
+            {
+                $pull: {
+                    items: { _id: inventoryItemId }
+                }
+            },
+            { new: true }
+        ).lean();
+    }
+
+    async removeItemByItemId(inventoryId, itemId) {
+        return await InventoryCategory.findOneAndUpdate(
+            { _id: inventoryId },
+            {
+                $pull: {
+                    items: { item: itemId }
+                }
+            },
+            { new: true }
+        ).lean();
+    }
+
+    async removeNonPositiveQuantityItemByInventoryItemId(
+        inventoryId,
+        inventoryItemId
+    ) {
+        return await InventoryCategory.findOneAndUpdate(
+            { _id: inventoryId },
+            {
+                $pull: {
+                    items: {
+                        _id: inventoryItemId,
+                        quantity: { $lte: 0 }
+                    }
+                }
+            },
+            { new: true }
+        ).lean();
+    }
+
+    async removeNonPositiveQuantityItemByItemId(inventoryId, itemId) {
+        return await InventoryCategory.findOneAndUpdate(
+            { _id: inventoryId },
+            {
+                $pull: {
+                    items: {
+                        item: itemId,
+                        quantity: { $lte: 0 }
+                    }
+                }
+            },
+            { new: true }
+        ).lean();
+    }
 }
 
 export default InventoryModel;


### PR DESCRIPTION
### 📝 작업 개요

- 인벤토리 수량 갱신 경로를 read-modify-write 방식에서 MongoDB 원자 연산 기반으로 전환했습니다.

### 🔧 주요 변경 사항

- `src/db/models/inventoryModel.js`
- 원자 업데이트 메서드 추가
- `adjustItemQuantityByInventoryItemId` (`$inc`)
- `adjustItemQuantityByItemId` (`$inc`)
- `addItemIfNotExists` (`$push`)
- `removeInventoryItem` (`$pull`)
- `removeNonPositiveQuantityItemByInventoryItemId` (`$pull`)
- `removeNonPositiveQuantityItemByItemId` (`$pull`)
- `src/services/inventoryService.js`
- 대상 메서드 원자화
- `addItemToInventory`
- `updateInventoryItemQuantity`
- `useItemAndUpdateInventory`
- `addSelectedItemToInventory`
- 보상 경로 수량 갱신(`updateInventoryItemReward`)도 원자 연산으로 전환
- 수량 검증 추가
- 정수 여부 확인
- 0 수량 차단
- 음수 차감 시 재고 부족(수량 미만) 조건 검증

### 🎯 변경 목적

- 동시 요청에서 Lost Update를 방지하고 인벤토리 수량 정합성을 유지하기 위함입니다.
- 음수 수량 저장을 방지해 데이터 무결성을 강화하기 위함입니다.

### 🧪 검증 방법

- `node --check src/db/models/inventoryModel.js`
- `node --check src/services/inventoryService.js`
- `npm run build`

### 📌 참고 사항

- 현재 저장소에는 동시성 자동 테스트 코드가 없어, 이번 PR에서는 원자 연산 쿼리 전환과 타입/빌드 검증으로 대체했습니다.

---

Closes #48
