### PR TITLE
fix: 회원탈퇴 토큰 쿠키 설정 버그 수정 (#45)

### DIFF
--- a/src/routers/authRouter.js
+++ b/src/routers/authRouter.js
@@ -218,12 +218,12 @@ authRouter.post(
       await todoContentService.deleteAllTodoContentsByUserId(userId);
       await todoCategoryService.deleteAllTodoCategoiesByUserId(userId);
 
-      // WithdrawUserAndToken 메서드를 호출하여 새로운 토큰 얻기
-      const newToken = await userService.WithdrawUserAndToken(userId);
-
-      // 기존 토큰 삭제 및 새로운 토큰 저장
-      res.clearCookie('token');
-      res.cookie('token', newToken);
+      await userService.withdrawUser(userId);
+      res.clearCookie('token', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none'
+      });
 
       res.status(200).json({ message: '탈퇴 처리 완료' });
     } catch (error) {

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -125,18 +125,6 @@ class UserService {
     }
   }
 
-  async WithdrawUserAndToken(userId) {
-    try {
-      // 회원 탈퇴 처리와 새로운 토큰 발급 수행
-      const newToken = await this.withdrawUser(userId);
-
-      return newToken; // 새로운 토큰 반환
-    } catch (error) {
-      console.error('Error withdrawing user:', error);
-      throw error; // 에러 다시 throw
-    }
-  }
-
   async withdrawUser(userId) {
     const updateResult = await this.userModel.updateMembershipStatus(
       userId,


### PR DESCRIPTION
### 📝 작업 개요

- 회원탈퇴 시 사용자 객체를 `token` 쿠키에 저장하던 버그를 제거하고, 쿠키 제거 중심으로 탈퇴 흐름을 정리했습니다.

### 🔧 주요 변경 사항

- `src/routers/authRouter.js`
- `/withdraw`에서 `WithdrawUserAndToken` 호출 제거
- `userService.withdrawUser(userId)`만 수행하도록 변경
- `res.cookie('token', newToken)` 제거
- `res.clearCookie('token', { httpOnly, secure, sameSite })`로 쿠키 삭제 명시
- `src/services/userService.js`
- 반환 타입 혼동 유발 메서드 `WithdrawUserAndToken` 제거
- 탈퇴 상태 변경은 `withdrawUser` 단일 메서드로 유지

### 🎯 변경 목적

- 탈퇴 후 잘못된 쿠키 값 저장을 방지하고 인증 오작동 가능성을 제거하기 위함입니다.

### 🧪 검증 방법

- `node --check src/routers/authRouter.js`
- `node --check src/services/userService.js`
- `npm run build`
- `rg -n "WithdrawUserAndToken|res\\.cookie\\('token', newToken\\)" src` (잔존 코드 없음)

### 📌 참고 사항

- 쿠키 삭제 옵션을 로그인 시 쿠키 설정(`httpOnly`, `secure`, `sameSite`)과 일치시켰습니다.

---

Closes #45
