### PR TITLE
fix: deletePetStorageByUserId 생성 부작용 제거 (#52)

### DIFF
--- a/src/services/myPetService.js
+++ b/src/services/myPetService.js
@@ -336,7 +336,7 @@ class MyPetService {
 
   //회원 탈퇴시 펫보관함 삭제
   async deletePetStorageByUserId(userId) {
-    const petStorage = await this.getMyPet(userId);
+    const petStorage = await this.myPetModel.findByUserId(userId);
     if (petStorage) {
       await this.myPetModel.delete(petStorage._id);
     }


### PR DESCRIPTION
### 📝 작업 개요

- `deletePetStorageByUserId`에서 조회/생성 책임이 섞여 있던 문제를 분리해, 삭제 경로의 생성 부작용을 제거했습니다.

### 🔧 주요 변경 사항

- `src/services/myPetService.js`
- `deletePetStorageByUserId(userId)`
  - 변경 전: `getMyPet(userId)` 호출(없으면 생성)
  - 변경 후: `myPetModel.findByUserId(userId)` 직접 조회
- 보관함이 있을 때만 삭제 수행하도록 유지

### 🎯 변경 목적

- 탈퇴/정리 로직 실행 시 불필요한 보관함 생성→삭제 쓰기 부작용을 제거하기 위함입니다.

### 🧪 검증 방법

- `node --check src/services/myPetService.js`
- `npm run build`

### 📌 참고 사항

- `getMyPet`의 생성 보장 책임은 유지되며, 삭제 경로에서만 생성 로직과 분리되었습니다.

---

Closes #52
