### PR TITLE
fix: signatureMiddleware를 HMAC+nonce 검증으로 교체 (#44)

### DIFF
--- a/src/middlewares/signatureMiddleware.js
+++ b/src/middlewares/signatureMiddleware.js
@@ -1,22 +1,105 @@
 import { buildResponse } from '../misc/utils.js';
+import crypto from 'crypto';
+
+const SIGNATURE_SECRET = process.env.SIGNATURE_SECRET;
+const SIGNATURE_WINDOW_MS = Number(process.env.SIGNATURE_WINDOW_MS ?? 5 * 60 * 1000);
+const usedNonces = new Map();
+
+const FORBIDDEN_ERROR = {
+  statusCode: 403,
+  result: 'Forbidden',
+  reason: '유효하지 않은 요청 서명입니다.'
+};
+
+const stableStringify = (value) => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  const sortedKeys = Object.keys(value).sort();
+  const entries = sortedKeys.map(
+    (key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`
+  );
+  return `{${entries.join(',')}}`;
+};
+
+const createPayload = (timestamp, nonce, body) => {
+  const bodyText = stableStringify(body ?? {});
+  return `${timestamp}.${nonce}.${bodyText}`;
+};
+
+const createSignature = (payload) => {
+  return crypto
+    .createHmac('sha256', SIGNATURE_SECRET)
+    .update(payload)
+    .digest('hex');
+};
+
+const isValidSignature = (receivedSignature, expectedSignature) => {
+  if (!receivedSignature || !expectedSignature) return false;
+  const receivedBuffer = Buffer.from(receivedSignature, 'hex');
+  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+
+  if (receivedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(receivedBuffer, expectedBuffer);
+};
+
+const cleanupExpiredNonces = (now) => {
+  for (const [nonce, expiresAt] of usedNonces.entries()) {
+    if (expiresAt <= now) {
+      usedNonces.delete(nonce);
+    }
+  }
+};
 
 const signatureMiddleware = (req, res, next) => {
-  const receivedTime = req.headers['x-custom-data'];
-  const checkReceivedTime = (receivedTime - 1000) / 4;
-  const maxTimeDifference = 60 * 1000; // 1분 (밀리초 단위)
-  const currentTime = Date.now();
-  const timeDifference = currentTime - checkReceivedTime;
-  if (timeDifference <= maxTimeDifference) {
-    next();
-  } else {
-    return res.json(
-      buildResponse({
-        status: 403,
-        result: 'Forbidden',
-        reason: '유효하지 않은 토큰입니다.'
+  if (!SIGNATURE_SECRET) {
+    console.error('[Signature] SIGNATURE_SECRET is not configured.');
+    return res.status(500).json(
+      buildResponse(null, {
+        statusCode: 500,
+        result: 'InternalServerError',
+        reason: '서명 검증 설정이 누락되었습니다.'
       })
     );
   }
+
+  const timestampHeader = req.headers['x-timestamp'];
+  const nonce = req.headers['x-nonce'];
+  const receivedSignature = req.headers['x-signature'];
+
+  const timestamp = Number(timestampHeader);
+  const now = Date.now();
+
+  if (!Number.isFinite(timestamp) || !nonce || !receivedSignature) {
+    return res.status(403).json(buildResponse(null, FORBIDDEN_ERROR));
+  }
+
+  if (Math.abs(now - timestamp) > SIGNATURE_WINDOW_MS) {
+    return res.status(403).json(buildResponse(null, FORBIDDEN_ERROR));
+  }
+
+  cleanupExpiredNonces(now);
+  if (usedNonces.has(nonce)) {
+    return res.status(403).json(buildResponse(null, FORBIDDEN_ERROR));
+  }
+
+  const payload = createPayload(timestamp, nonce, req.body);
+  const expectedSignature = createSignature(payload);
+
+  if (!isValidSignature(receivedSignature, expectedSignature)) {
+    return res.status(403).json(buildResponse(null, FORBIDDEN_ERROR));
+  }
+
+  usedNonces.set(nonce, now + SIGNATURE_WINDOW_MS);
+  return next();
 };
 
 export default signatureMiddleware;


### PR DESCRIPTION
### 📝 작업 개요

- 취약한 시간 계산 기반 서명 검증 로직을 제거하고, HMAC + timestamp + nonce 기반 검증으로 교체했습니다.

### 🔧 주요 변경 사항

- `src/middlewares/signatureMiddleware.js`
- 헤더 기반 검증으로 변경
- `x-timestamp`, `x-nonce`, `x-signature`
- 서명 생성 방식
- payload: `timestamp + nonce + canonicalized body`
- 알고리즘: `HMAC-SHA256`
- `crypto.timingSafeEqual`로 서명 비교
- 시간창 검증 추가
- `SIGNATURE_WINDOW_MS`(기본 5분)
- nonce 재사용 방지 저장소(Map) + 만료 정리 로직 추가
- 검증 실패 시 `403` 상태코드로 명시 응답

### 🎯 변경 목적

- replay 공격 및 위조 서명 우회를 차단해 민감 API 보호를 강화하기 위함입니다.

### 🧪 검증 방법

- `node --check src/middlewares/signatureMiddleware.js`
- `npm run build`
- `rg -n "x-custom-data|x-timestamp|x-nonce|x-signature|SIGNATURE_SECRET" src/middlewares/signatureMiddleware.js`

### 📌 참고 사항

- 환경변수 `SIGNATURE_SECRET` 설정이 필요합니다.
- 미설정 시 보안상 요청을 허용하지 않고 500 응답을 반환합니다.

---

Closes #44
